### PR TITLE
Displays help if a required arg is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "js-yaml": "^3.12.1"
   },
   "bin": {
-    "swagger-min": "swagger-min.js"
+    "swagger-min": "swagger-min-cli.js"
   },
   "devDependencies": {
     "mocha": "^5.2.0"

--- a/swagger-min-cli.js
+++ b/swagger-min-cli.js
@@ -7,11 +7,15 @@ pkg     = require('./package.json');
 
 program
     .version(pkg.version)
-    .option('-f, --file [path]', 'The path to the swagger document')
-    .option('-v, --verb [verb]', 'The verb that should be hit')
-    .option('-r, --route [route]', 'The route')
+    .option('-f, --file [path]',   '[required] The path to the swagger document')
+    .option('-v, --verb [verb]',   '[required] The verb that should be hit')
+    .option('-r, --route [route]', '[required] The route')
 
 program.parse(process.argv);
+
+if (!program.file || !program.verb || !program.route) {
+    program.help();
+}
 
 function isObject(a) {
     return (!!a) && (a.constructor === Object);


### PR DESCRIPTION
Fixes #9

* Renames swagger-min.js to swagger-min-cli.js to prepare to
  split logic between the cli and the core algorithm